### PR TITLE
Add Trivy Security Scans

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,18 +65,18 @@ runs:
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
       shell: bash
-- name: Trivy Security Scan
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-jobs:
-  build:
+    - name: Trivy Security Scanning
+      on:
+        push:
+          branches: [ master ]
+        pull_request:
+          branches: [ master ]
+  jobs:
+   build:
     runs-on: ubuntu-18.04
     steps:
-    - uses: aquasecurity/trivy-action@master
- - name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
+    uses: aquasecurity/trivy-action@master
+ - name: Run Trivy vulnerability scanner in repo mode
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'
@@ -88,7 +88,7 @@ jobs:
         exit-code: 0
         # severity of vulnerabilities
         severity: 'UNKNOWN,LOW,MEDIUM'
- - name: Run Trivy Scan in Repo Mode - High and Critical Severity
+ - name: Run Trivy scan in repo mode high and critical severity
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'

--- a/action.yml
+++ b/action.yml
@@ -65,41 +65,37 @@ runs:
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
       shell: bash
-    - name: Trivy Security Scanning
-      on:
-        push:
-          branches: [ master ]
-        pull_request:
-          branches: [ master ]
-  jobs:
-   build:
+- name: Run Trivy Security Scan
+  on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    jobs:
+    build:
     runs-on: ubuntu-18.04
     steps:
     uses: aquasecurity/trivy-action@master
- - name: Run Trivy vulnerability scanner in repo mode
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        ignore-unfixed: true
-        format: 'template'
-        template: '@/contrib/sarif.tpl'
-        output: 'trivy-results.sarif'
-        # exit code when vulnerabilities are found
-        exit-code: 0
-        # severity of vulnerabilities
-        severity: 'UNKNOWN,LOW,MEDIUM'
- - name: Run Trivy scan in repo mode high and critical severity
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        ignore-unfixed: true
-        format: 'template'
-        template: '@/contrib/sarif.tpl'
-        output: 'trivy-results.sarif'
-        # exit code when vulnerabilities are found
-        exit-code: 1
-        # severity of vulnerabilities
-        severity: 'HIGH,CRITICAL'
+- name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
+  uses: aquasecurity/trivy-action@master
+  with:
+    scan-type: 'fs'
+    ignore-unfixed: true
+    format: 'template'
+    template: '@/contrib/sarif.tpl'
+    output: 'trivy-results.sarif'
+    exit-code: 0
+    severity: UNKNOWN,LOW,MEDIUM
+- name: Run Trivy Scan in Repo Mode - High and Critical Severity
+  uses: aquasecurity/trivy-action@master
+  with:
+    scan-type: 'fs'
+    ignore-unfixed: true
+    format: 'template'
+    template: '@/contrib/sarif.tpl'
+    output: 'trivy-results.sarif'
+    exit-code: 1
+    severity: HIGH,CRITICAL
     - name: Publish SNAPSHOT
       run: |-
         test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0

--- a/action.yml
+++ b/action.yml
@@ -65,75 +65,72 @@
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
       shell: bash
-- name: Run Trivy Security Scan
-  on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-    jobs:
-    build:
-    runs-on: ubuntu-18.04
-    steps:
-    uses: aquasecurity/trivy-action@master
+  ###########################################
+  # Download and install Trivy and template #
+  ###########################################
+- name: Download and Install Trivy
+  shell: bash
+  run: |
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b ${GITHUB_WORKSPACE}
+    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/sarif.tpl -o sarif.tpl
 - name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
   uses: aquasecurity/trivy-action@master
   with:
-    scan-type: 'fs'
+    scan-type: "fs"
     ignore-unfixed: true
-    format: 'template'
-    template: '@/contrib/sarif.tpl'
-    output: 'trivy-results.sarif'
+    format: "template"
+    template: "@/contrib/sarif.tpl"
+    output: "trivy-results.sarif"
     exit-code: 0
     severity: UNKNOWN,LOW,MEDIUM
 - name: Run Trivy Scan in Repo Mode - High and Critical Severity
   uses: aquasecurity/trivy-action@master
   with:
-    scan-type: 'fs'
+    scan-type: "fs"
     ignore-unfixed: true
-    format: 'template'
-    template: '@/contrib/sarif.tpl'
-    output: 'trivy-results.sarif'
+    format: "template"
+    template: "@/contrib/sarif.tpl"
+    output: "trivy-results.sarif"
     exit-code: 1
     severity: HIGH,CRITICAL
 - name: Publish SNAPSHOT
   run: |-
-        test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0
-        mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
-        find . -path '**target/nexus-staging/deferred/.index' -exec sed -i 's@:camunda-nexus:.*$@:central:https://oss.sonatype.org/content/repositories/snapshots/@g' {} +
-        mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged
+    test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0
+    mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
+    find . -path '**target/nexus-staging/deferred/.index' -exec sed -i 's@:camunda-nexus:.*$@:central:https://oss.sonatype.org/content/repositories/snapshots/@g' {} +
+    mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged
   shell: bash
   env:
-        NEXUS_USR: ${{ inputs.nexus-usr}}
-        NEXUS_PSW: ${{ inputs.nexus-psw }}
-        MAVEN_USR: ${{ inputs.maven-usr }}
-        MAVEN_PSW: ${{ inputs.maven-psw }}
+    NEXUS_USR: ${{ inputs.nexus-usr}}
+    NEXUS_PSW: ${{ inputs.nexus-psw }}
+    MAVEN_USR: ${{ inputs.maven-usr }}
+    MAVEN_PSW: ${{ inputs.maven-psw }}
 - name: Publish Maven Release
   run: |-
-        test -z "${{ inputs.release-version }}" && echo "::debug::Skipping Release because release-version is unset" && exit 0
-        # 1. set version
-        mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
-        # 2. perform release
-        mvn -B ${{ inputs.maven-additional-options }} ${RELEASE_PROFILE} ${{ inputs.maven-release-options }} -DskipTests -DnexusUrl=https://oss.sonatype.org/ -DserverId=central -Drelease-version=${{ inputs.release-version }} -Dgpg.sign initialize \
-          package source:jar javadoc:jar \
-          deploy org.apache.maven.plugins:maven-gpg-plugin:sign \
-          nexus-staging:deploy
+    test -z "${{ inputs.release-version }}" && echo "::debug::Skipping Release because release-version is unset" && exit 0
+    # 1. set version
+    mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
+    # 2. perform release
+    mvn -B ${{ inputs.maven-additional-options }} ${RELEASE_PROFILE} ${{ inputs.maven-release-options }} -DskipTests -DnexusUrl=https://oss.sonatype.org/ -DserverId=central -Drelease-version=${{ inputs.release-version }} -Dgpg.sign initialize \
+      package source:jar javadoc:jar \
+      deploy org.apache.maven.plugins:maven-gpg-plugin:sign \
+      nexus-staging:deploy
   shell: bash
   env:
-        NEXUS_USR: ${{ inputs.nexus-usr}}
-        NEXUS_PSW: ${{ inputs.nexus-psw }}
-        MAVEN_USR: ${{ inputs.maven-usr }}
-        MAVEN_PSW: ${{ inputs.maven-psw }}
-        MAVEN_GPG_PASSPHRASE: ${{ inputs.maven-gpg-passphrase }}
+    NEXUS_USR: ${{ inputs.nexus-usr}}
+    NEXUS_PSW: ${{ inputs.nexus-psw }}
+    MAVEN_USR: ${{ inputs.maven-usr }}
+    MAVEN_PSW: ${{ inputs.maven-psw }}
+    MAVEN_GPG_PASSPHRASE: ${{ inputs.maven-gpg-passphrase }}
 - name: Prepare next development version
   run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ github.event.repository.default_branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
   shell: bash
 - name: Archive artifacts
   run: |-
-        test -z "${{ inputs.artifacts-pattern }}" && echo "::debug::Skipping archiving because artifacts-pattern is unset" && exit 0
-        # Filename: [repo without org]-[version].zip
-        ZIPFILE=${GITHUB_REPOSITORY#*/}-${{ inputs.release-version }}.zip
-        zip $ZIPFILE $(find . -path ${{ inputs.artifacts-pattern }})
-        echo "::set-output name=filename::${ZIPFILE}"
+    test -z "${{ inputs.artifacts-pattern }}" && echo "::debug::Skipping archiving because artifacts-pattern is unset" && exit 0
+    # Filename: [repo without org]-[version].zip
+    ZIPFILE=${GITHUB_REPOSITORY#*/}-${{ inputs.release-version }}.zip
+    zip $ZIPFILE $(find . -path ${{ inputs.artifacts-pattern }})
+    echo "::set-output name=filename::${ZIPFILE}"
   shell: bash
   id: create-archive

--- a/action.yml
+++ b/action.yml
@@ -75,10 +75,21 @@
 - name: Download and Install Trivy
   shell: bash
   run: |
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b ${GITHUB_WORKSPACE}
-    curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/sarif.tpl -o sarif.tpl
-    trivy --version
-    exit 1
+    if [[ "${{ inputs.vulnerability-scan }}" == "true" ]];
+    then
+      curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b ${GITHUB_WORKSPACE}
+      curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/sarif.tpl -o sarif.tpl
+      ./trivy --version
+      ./trivy fs -t @sarif.tpl -f template -o trivy-results.sarif .
+
+      if [[ $(cat trivy-results.sarif | grep -E 'Severity: (HIGH|CRITICAL)' | wc -l) > 0 ]];
+      then
+        ./trivy fs .
+        exit 1
+      else
+        exit 0
+      fi
+    fi
 - name: Publish SNAPSHOT
   run: |-
     test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-- name: Release Camunda Community Project on Maven Central
-  description: Encapsulates the release process of Camunda community extensions
-  inputs:
+name: Release Camunda Community Project on Maven Central
+description: Encapsulates the release process of Camunda community extensions
+inputs:
   artifacts-pattern:
     description: Which artifacts to store. Set to empty string to disable
     required: false
@@ -48,12 +48,12 @@
   vulnerability-scan:
     description: TODO
     required: false
-    default: true
-  outputs:
+    default: "false"
+outputs:
   artifacts_archive_path:
     description: Filename of zipfile containing all files matched by artifacts-pattern.
     value: ${{ steps.create-archive.outputs.filename }}
-  runs:
+runs:
   using: composite
   steps:
     - name: Initialize
@@ -69,65 +69,65 @@
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
       shell: bash
-  ###########################################
-  # Download and install Trivy and template #
-  ###########################################
-- name: Download and Install Trivy
-  shell: bash
-  run: |
-    if [[ "${{ inputs.vulnerability-scan }}" == "true" ]];
-    then
-      curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b ${GITHUB_WORKSPACE}
-      curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/sarif.tpl -o sarif.tpl
-      ./trivy --version
-      ./trivy fs -t @sarif.tpl -f template -o trivy-results.sarif .
+      ###########################################
+      # Download and install Trivy and template #
+      ###########################################
+    - name: Download and Install Trivy
+      shell: bash
+      run: |
+        if [[ "${{ inputs.vulnerability-scan }}" == "true" ]];
+        then
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b ${GITHUB_WORKSPACE}
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/sarif.tpl -o sarif.tpl
+          ./trivy --version
+          ./trivy fs -t @sarif.tpl -f template -o trivy-results.sarif .
 
-      if [[ $(cat trivy-results.sarif | grep -E 'Severity: (HIGH|CRITICAL)' | wc -l) > 0 ]];
-      then
-        ./trivy fs .
-        exit 1
-      else
-        exit 0
-      fi
-    fi
-- name: Publish SNAPSHOT
-  run: |-
-    test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0
-    mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
-    find . -path '**target/nexus-staging/deferred/.index' -exec sed -i 's@:camunda-nexus:.*$@:central:https://oss.sonatype.org/content/repositories/snapshots/@g' {} +
-    mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged
-  shell: bash
-  env:
-    NEXUS_USR: ${{ inputs.nexus-usr}}
-    NEXUS_PSW: ${{ inputs.nexus-psw }}
-    MAVEN_USR: ${{ inputs.maven-usr }}
-    MAVEN_PSW: ${{ inputs.maven-psw }}
-- name: Publish Maven Release
-  run: |-
-    test -z "${{ inputs.release-version }}" && echo "::debug::Skipping Release because release-version is unset" && exit 0
-    # 1. set version
-    mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
-    # 2. perform release
-    mvn -B ${{ inputs.maven-additional-options }} ${RELEASE_PROFILE} ${{ inputs.maven-release-options }} -DskipTests -DnexusUrl=https://oss.sonatype.org/ -DserverId=central -Drelease-version=${{ inputs.release-version }} -Dgpg.sign initialize \
-      package source:jar javadoc:jar \
-      deploy org.apache.maven.plugins:maven-gpg-plugin:sign \
-      nexus-staging:deploy
-  shell: bash
-  env:
-    NEXUS_USR: ${{ inputs.nexus-usr}}
-    NEXUS_PSW: ${{ inputs.nexus-psw }}
-    MAVEN_USR: ${{ inputs.maven-usr }}
-    MAVEN_PSW: ${{ inputs.maven-psw }}
-    MAVEN_GPG_PASSPHRASE: ${{ inputs.maven-gpg-passphrase }}
-- name: Prepare next development version
-  run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ github.event.repository.default_branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
-  shell: bash
-- name: Archive artifacts
-  run: |-
-    test -z "${{ inputs.artifacts-pattern }}" && echo "::debug::Skipping archiving because artifacts-pattern is unset" && exit 0
-    # Filename: [repo without org]-[version].zip
-    ZIPFILE=${GITHUB_REPOSITORY#*/}-${{ inputs.release-version }}.zip
-    zip $ZIPFILE $(find . -path ${{ inputs.artifacts-pattern }})
-    echo "::set-output name=filename::${ZIPFILE}"
-  shell: bash
-  id: create-archive
+          if [[ $(cat trivy-results.sarif | grep -E 'Severity: (HIGH|CRITICAL)' | wc -l) > 0 ]];
+          then
+            ./trivy fs .
+            exit 1
+          else
+            exit 0
+          fi
+        fi
+    - name: Publish SNAPSHOT
+      run: |-
+        test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0
+        mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
+        find . -path '**target/nexus-staging/deferred/.index' -exec sed -i 's@:camunda-nexus:.*$@:central:https://oss.sonatype.org/content/repositories/snapshots/@g' {} +
+        mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged
+      shell: bash
+      env:
+        NEXUS_USR: ${{ inputs.nexus-usr}}
+        NEXUS_PSW: ${{ inputs.nexus-psw }}
+        MAVEN_USR: ${{ inputs.maven-usr }}
+        MAVEN_PSW: ${{ inputs.maven-psw }}
+    - name: Publish Maven Release
+      run: |-
+        test -z "${{ inputs.release-version }}" && echo "::debug::Skipping Release because release-version is unset" && exit 0
+        # 1. set version
+        mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
+        # 2. perform release
+        mvn -B ${{ inputs.maven-additional-options }} ${RELEASE_PROFILE} ${{ inputs.maven-release-options }} -DskipTests -DnexusUrl=https://oss.sonatype.org/ -DserverId=central -Drelease-version=${{ inputs.release-version }} -Dgpg.sign initialize \
+          package source:jar javadoc:jar \
+          deploy org.apache.maven.plugins:maven-gpg-plugin:sign \
+          nexus-staging:deploy
+      shell: bash
+      env:
+        NEXUS_USR: ${{ inputs.nexus-usr}}
+        NEXUS_PSW: ${{ inputs.nexus-psw }}
+        MAVEN_USR: ${{ inputs.maven-usr }}
+        MAVEN_PSW: ${{ inputs.maven-psw }}
+        MAVEN_GPG_PASSPHRASE: ${{ inputs.maven-gpg-passphrase }}
+    - name: Prepare next development version
+      run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ github.event.repository.default_branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
+      shell: bash
+    - name: Archive artifacts
+      run: |-
+        test -z "${{ inputs.artifacts-pattern }}" && echo "::debug::Skipping archiving because artifacts-pattern is unset" && exit 0
+        # Filename: [repo without org]-[version].zip
+        ZIPFILE=${GITHUB_REPOSITORY#*/}-${{ inputs.release-version }}.zip
+        zip $ZIPFILE $(find . -path ${{ inputs.artifacts-pattern }})
+        echo "::set-output name=filename::${ZIPFILE}"
+      shell: bash
+      id: create-archive

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 - name: Release Camunda Community Project on Maven Central
-description: Encapsulates the release process of Camunda community extensions
-inputs:
+  description: Encapsulates the release process of Camunda community extensions
+  inputs:
   artifacts-pattern:
-    description: Which artifacts to store. Set to empty string to disable.
+    description: Which artifacts to store. Set to empty string to disable
     required: false
     default: ./target/nexus-staging/**/*.jar
   run-tests:
@@ -45,11 +45,11 @@ inputs:
     description: Any extra Maven options for the initial build process
     required: false
     default: ""
-outputs:
+  outputs:
   artifacts_archive_path:
     description: Filename of zipfile containing all files matched by artifacts-pattern.
     value: ${{ steps.create-archive.outputs.filename }}
-runs:
+  runs:
   using: composite
   steps:
     - name: Initialize
@@ -96,20 +96,20 @@ runs:
     output: 'trivy-results.sarif'
     exit-code: 1
     severity: HIGH,CRITICAL
-    - name: Publish SNAPSHOT
-      run: |-
+- name: Publish SNAPSHOT
+  run: |-
         test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0
         mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
         find . -path '**target/nexus-staging/deferred/.index' -exec sed -i 's@:camunda-nexus:.*$@:central:https://oss.sonatype.org/content/repositories/snapshots/@g' {} +
         mvn -B ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged
-      shell: bash
-      env:
+  shell: bash
+  env:
         NEXUS_USR: ${{ inputs.nexus-usr}}
         NEXUS_PSW: ${{ inputs.nexus-psw }}
         MAVEN_USR: ${{ inputs.maven-usr }}
         MAVEN_PSW: ${{ inputs.maven-psw }}
-    - name: Publish Maven Release
-      run: |-
+- name: Publish Maven Release
+  run: |-
         test -z "${{ inputs.release-version }}" && echo "::debug::Skipping Release because release-version is unset" && exit 0
         # 1. set version
         mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
@@ -118,22 +118,22 @@ runs:
           package source:jar javadoc:jar \
           deploy org.apache.maven.plugins:maven-gpg-plugin:sign \
           nexus-staging:deploy
-      shell: bash
-      env:
+  shell: bash
+  env:
         NEXUS_USR: ${{ inputs.nexus-usr}}
         NEXUS_PSW: ${{ inputs.nexus-psw }}
         MAVEN_USR: ${{ inputs.maven-usr }}
         MAVEN_PSW: ${{ inputs.maven-psw }}
         MAVEN_GPG_PASSPHRASE: ${{ inputs.maven-gpg-passphrase }}
-    - name: Prepare next development version
-      run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ github.event.repository.default_branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
-      shell: bash
-    - name: Archive artifacts
-      run: |-
+- name: Prepare next development version
+  run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ github.event.repository.default_branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
+  shell: bash
+- name: Archive artifacts
+  run: |-
         test -z "${{ inputs.artifacts-pattern }}" && echo "::debug::Skipping archiving because artifacts-pattern is unset" && exit 0
         # Filename: [repo without org]-[version].zip
         ZIPFILE=${GITHUB_REPOSITORY#*/}-${{ inputs.release-version }}.zip
         zip $ZIPFILE $(find . -path ${{ inputs.artifacts-pattern }})
         echo "::set-output name=filename::${ZIPFILE}"
-      shell: bash
-      id: create-archive
+  shell: bash
+  id: create-archive

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,37 @@ runs:
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
       shell: bash
+    - name: Trivy Security Scan
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: aquasecurity/trivy-action@master
+    - name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
+      uses: aquasecurity/trivy-action@master
+      with:
+       scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+        exit-code: 0
+        severity: UNKNOWN,LOW,MEDIUM
+    - name: Run Trivy Scan in Repo Mode - High and Critical Severity
+      uses: aquasecurity/trivy-action@master
+      with:
+       scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: 'trivy-results.sarif'
+        exit-code: 1
+        severity: HIGH,CRITICAL
     - name: Publish SNAPSHOT
       run: |-
         test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@
     description: Any extra Maven options for the initial build process
     required: false
     default: ""
+  vulnerability-scan:
+    description: TODO
+    required: false
+    default: true
   outputs:
   artifacts_archive_path:
     description: Filename of zipfile containing all files matched by artifacts-pattern.
@@ -73,26 +77,8 @@
   run: |
     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b ${GITHUB_WORKSPACE}
     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/sarif.tpl -o sarif.tpl
-- name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
-  uses: aquasecurity/trivy-action@master
-  with:
-    scan-type: "fs"
-    ignore-unfixed: true
-    format: "template"
-    template: "@/contrib/sarif.tpl"
-    output: "trivy-results.sarif"
-    exit-code: 0
-    severity: UNKNOWN,LOW,MEDIUM
-- name: Run Trivy Scan in Repo Mode - High and Critical Severity
-  uses: aquasecurity/trivy-action@master
-  with:
-    scan-type: "fs"
-    ignore-unfixed: true
-    format: "template"
-    template: "@/contrib/sarif.tpl"
-    output: "trivy-results.sarif"
-    exit-code: 1
-    severity: HIGH,CRITICAL
+    trivy --version
+    exit 1
 - name: Publish SNAPSHOT
   run: |-
     test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
       shell: bash
-    - name: Trivy Security Scan
+- name: Trivy Security Scan
 on:
   push:
     branches: [ master ]
@@ -76,26 +76,30 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: aquasecurity/trivy-action@master
-    - name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
+ - name: Run Trivy Scan in Repo Mode - Unknown, Low, and Medium Severity
       uses: aquasecurity/trivy-action@master
       with:
-       scan-type: 'fs'
-          ignore-unfixed: true
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
+        scan-type: 'fs'
+        ignore-unfixed: true
+        format: 'template'
+        template: '@/contrib/sarif.tpl'
+        output: 'trivy-results.sarif'
+        # exit code when vulnerabilities are found
         exit-code: 0
-        severity: UNKNOWN,LOW,MEDIUM
-    - name: Run Trivy Scan in Repo Mode - High and Critical Severity
+        # severity of vulnerabilities
+        severity: 'UNKNOWN,LOW,MEDIUM'
+ - name: Run Trivy Scan in Repo Mode - High and Critical Severity
       uses: aquasecurity/trivy-action@master
       with:
-       scan-type: 'fs'
-          ignore-unfixed: true
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
-          output: 'trivy-results.sarif'
+        scan-type: 'fs'
+        ignore-unfixed: true
+        format: 'template'
+        template: '@/contrib/sarif.tpl'
+        output: 'trivy-results.sarif'
+        # exit code when vulnerabilities are found
         exit-code: 1
-        severity: HIGH,CRITICAL
+        # severity of vulnerabilities
+        severity: 'HIGH,CRITICAL'
     - name: Publish SNAPSHOT
       run: |-
         test -n "${{ inputs.release-version }}" && echo "::debug::Not publishing SNAPSHOT because release-version is set" && exit 0

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Release Camunda Community Project on Maven Central
+- name: Release Camunda Community Project on Maven Central
 description: Encapsulates the release process of Camunda community extensions
 inputs:
   artifacts-pattern:


### PR DESCRIPTION
Description: This pull request introduces two Trivy security scans running in repo mode on both <code> PUSH </code> and <code> PULL </code> requests.

The first scan checks for unknown, low, and medium security vulnerabilities, returns an exit-code: 0, and formats the scan results into  a template. 

The second scan runs in repo mode and checks for high and critical vulnerabilities, fails with exit-code: 1 if vulnerabilities are found, and formats the scan results into a template.