### PR TITLE
Configure git branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If there are no vulnerabilities found, or `UNKNOWN,` `LOW,` or `MEDIUM` vulnerab
 
 The [v1.0.7 release](https://github.com/camunda-community-hub/community-action-maven-release/releases/tag/v1.0.7) introduces uploading the results of a Trivy vulnerability scan that has completed with `exit 1` contained in a Sarif file to the [GitHub Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security) tab.
 
-> ![A BPMN diagram of the release workflow](https://github.com/camunda-community-hub/community/blob/main/assets/release-new-version%20(1).png)
+> ![A BPMN diagram of the release workflow](<https://github.com/camunda-community-hub/community/blob/main/assets/release-new-version%20(1).png>)
 
 ### Usage
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: URL of Maven Central/Sonatype, e.g. newer domains are hosted under s01.oss.sonatype.org
     required: false
     default: "oss.sonatype.org"
+  branch:
+    description: Branch on which the new version numbers will be committed
+    required: false
+    default: ${{ github.event.repository.default_branch }}
 outputs:
   artifacts_archive_path:
     description: Filename of zipfile containing all files matched by artifacts-pattern.
@@ -147,7 +151,7 @@ runs:
         MAVEN_PSW: ${{ inputs.maven-psw }}
         MAVEN_GPG_PASSPHRASE: ${{ inputs.maven-gpg-passphrase }}
     - name: Prepare next development version
-      run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ github.event.repository.default_branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
+      run: ${{ github.action_path }}/resources/prepare-next-development-version.sh "${{ inputs.branch }}" "${{ inputs.release-version }}" "${{ inputs.maven-additional-options }}"
       shell: bash
     - name: Archive artifacts
       run: |-

--- a/resources/prepare-next-development-version.sh
+++ b/resources/prepare-next-development-version.sh
@@ -2,17 +2,18 @@
 
 
 RELEASE_VERSION=$2
-DEFAULT_BRANCH=$1
+BRANCH=$1
 MAVEN_ADDITIONAL_OPTIONS=$3
 
 [ $# != 3 ] && echo "::error::prepare-next-development-version needs exactly 3 arguments." && exit 1
 test -z "${RELEASE_VERSION}" && echo "::debug::Skipping Release because release-version is unset" && exit 0
-test -z "${DEFAULT_BRANCH}" && echo "::error::Default branch needs to be passed" && exit 1
+test -z "${BRANCH}" && echo "::error::Default branch needs to be passed" && exit 1
 
 git fetch --no-tags
-git checkout "${DEFAULT_BRANCH}"
+git branch "${BRANCH}" "origin/${BRANCH}" || exit 1;
+git checkout "${BRANCH}"
 
-[ "$(git rev-list -n1 "${RELEASE_VERSION}")" != "$(git rev-list -n1 "${DEFAULT_BRANCH}")" ] && echo "${RELEASE_VERSION} not pointing to tip of ${DEFAULT_BRANCH}" && exit 0
+[ "$(git rev-list -n1 "${RELEASE_VERSION}")" != "$(git rev-list -n1 "${BRANCH}")" ] && echo "${RELEASE_VERSION} not pointing to tip of ${BRANCH}" && exit 0
 
 # Commit the release version change in the pom.xml
 git add ./**pom.xml


### PR DESCRIPTION
This enables users to add a branch as input to this action. When passed this branch will be used when updating the versions in maven. By default this branch will be the default branch of the repository (similar to the old behaviour).

This change gives users more freedom over their release process. For instance, if I want to support multiple versions and have different branches for managing this.

Imagine the following branches:
1. main
2. stable/1.0
3. stable/1.1

When I want to do a patch release on version 1.0, I want the versions to be updated on the stable/1.0 branch. I'd set the `branch` input to `stable/1.0` to achieve this.
Without this change making a new patch release for version 1.0 will result in an update of the main branch. Where the versions would've been 1.1 before, they'd be updated to 1.0 because of this patch.