### PR TITLE
Prevent second deployment to Maven Central

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,8 +146,8 @@ runs:
         mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
         echo "Deploy release to Camunda Repository using ${{inputs.release-profile}} profile"
         mvn -B ${RELEASE_PROFILE} ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
-        echo "Deploy release to Maven Central using profiles ${{inputs.release-profile}}, ${{inputs.central-release-profile}}"
-        mvn -B ${RELEASE_PROFILE} ${CENTRAL_RELEASE_PROFILE} ${{ inputs.maven-additional-options }} -DautoReleaseAfterClose=${{ inputs.maven-auto-release-after-close }} \
+        echo "Deploy release to Maven Central using profile ${{inputs.central-release-profile}}"
+        mvn -B ${CENTRAL_RELEASE_PROFILE} ${{ inputs.maven-additional-options }} -DautoReleaseAfterClose=${{ inputs.maven-auto-release-after-close }} \
          -DskipTests -DnexusUrl=https://${{inputs.maven-url}}/ ${{ inputs.maven-release-options }} deploy
       shell: bash
       env:


### PR DESCRIPTION
The RELEASE_PROFILE defaults to community-action-maven-release. Combined with community-hub-release-parent pom this will cause a deployment referred to as the `default-deployment`. The CENTRAL_RELEASE_PROFILE also causes a deployment. This one is referred to as the `deploy-to-maven-central` deployment.

By default, the `default-deployment` will deploy to the Camunda Repository. However, because  in this command the `nexusUrl` gets overridden with `inputs.maven-url` this deployment will be done to the same repository that is used for the `deploy-to-maven-central` deployment.

Since the deployment to the Camunda Repository already happens in a separate command a few lines above this one, we don't need this profile at all.

closes #45 