### PR TITLE
Revert "fix: prevent second deployment to Maven Central"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -146,8 +146,8 @@ runs:
         mvn -B ${{ inputs.maven-additional-options }} versions:set org.codehaus.mojo:versions-maven-plugin:2.8.1:update-child-modules -DnewVersion=${{ inputs.release-version }}
         echo "Deploy release to Camunda Repository using ${{inputs.release-profile}} profile"
         mvn -B ${RELEASE_PROFILE} ${{ inputs.maven-additional-options }} -DskipTests ${{ inputs.maven-release-options }} deploy
-        echo "Deploy release to Maven Central using profile ${{inputs.central-release-profile}}"
-        mvn -B ${CENTRAL_RELEASE_PROFILE} ${{ inputs.maven-additional-options }} -DautoReleaseAfterClose=${{ inputs.maven-auto-release-after-close }} \
+        echo "Deploy release to Maven Central using profiles ${{inputs.release-profile}}, ${{inputs.central-release-profile}}"
+        mvn -B ${RELEASE_PROFILE} ${CENTRAL_RELEASE_PROFILE} ${{ inputs.maven-additional-options }} -DautoReleaseAfterClose=${{ inputs.maven-auto-release-after-close }} \
          -DskipTests -DnexusUrl=https://${{inputs.maven-url}}/ ${{ inputs.maven-release-options }} deploy
       shell: bash
       env:


### PR DESCRIPTION
This reverts commit 91a3ff5c45055a189d6966de42dad547b4da034c.

These changes were supposed to fix an unintended double deployment. This is not what they do. Instead it breaks releases as the removed profile added some plugins that are required for a release to maven central.