### PR TITLE
Update action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add a GitHub workflow (e.g. by adding a file `.github/workflows/deploy.yaml` to 
 
 Important configuration options (see https://github.com/camunda-community-hub/community-action-maven-release/blob/main/action.yml#L3 for all options):
 
-- **Sonatype Server & Credentials:** 
+- **Sonatype Server & Credentials:**
 
 If you're using the org.camunda.community groupID, you need to use the OSS URL, username and password:
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ If you're using the io.camunda groupID, use the s01 credentials:
 
 > [!TIP]
 > Hint: Most Community Hub projects are in the `org.camunda.community` groupID.
+
 - **Branch:** If you want to support multiple versions and have different branches for managing those, you can configure them in the action: `branch: ${{ github.event.release.target_commitish || github.ref_name }}`
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
 
     - name: Archive Test Results on Failure
       id: upload-test-results-on-fail
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ inputs.run-tests && failure() }}
       with:
         name: test-results


### PR DESCRIPTION
The old version of the plugin leads to a failing pipeline, example: https://github.com/camunda-community-hub/camunda-7-to-8-migration/actions/runs/13056708353/job/36429465775