### PR TITLE
fix: add camunda-nexus-release server and set credentials for build step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
 
       - uses: pre-commit/action@v3.0.1

--- a/action.yml
+++ b/action.yml
@@ -155,13 +155,16 @@ runs:
 
     - name: Run maven
       shell: bash
+      env:
+        NEXUS_USR: ${{ inputs.nexus-usr }}
+        NEXUS_PSW: ${{ inputs.nexus-psw }}
       run: |-
         test -z "${{ inputs.run-tests }}" && SKIP_TESTS="-DskipTests"
         mvn -B ${{ inputs.maven-additional-options }} ${{ inputs.maven-build-options }} package ${SKIP_TESTS}
 
     - name: Archive Test Results on Failure
       if: ${{ inputs.run-tests && failure() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: test-results
         path: target/surefire-reports/
@@ -169,7 +172,7 @@ runs:
 
     - name: Publish Unit Test Results on Failure
       if: ${{ inputs.run-tests && failure() }}
-      uses: EnricoMi/publish-unit-test-result-action@v2.3.0
+      uses: EnricoMi/publish-unit-test-result-action@v2.23.0
       with:
         junit_files: target/surefire-reports/*.xml
 
@@ -207,7 +210,7 @@ runs:
             -d '{"commit_sha":"${GITHUB_SHA}","ref":"${GITHUB_REF}","sarif": "${COMPRESSED_SARIF}"}' || true
         fi
     - name: Actions tagger
-      uses: Actions-R-Us/actions-tagger@latest
+      uses: Actions-R-Us/actions-tagger@v2.0.3
       with:
         publish_latest_tag: true
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,6 +31,11 @@
           <password>${env.NEXUS_PSW}</password>
         </server>
         <server>
+          <id>camunda-nexus-release</id>
+          <username>${env.NEXUS_USR}</username>
+          <password>${env.NEXUS_PSW}</password>
+        </server>
+        <server>
             <id>central</id>
             <username>${env.MAVEN_USR}</username>
             <password>${env.MAVEN_PSW}</password>


### PR DESCRIPTION
## Problem

When using this action in repositories that depend on artifacts from Camunda's private Nexus repository (e.g. `zeebe-protocol-jackson`), the Maven build fails with **401 Unauthorized** during dependency resolution.

### Root cause

1. The action's `resources/settings.xml` only defines a `camunda-nexus` server entry, but many Camunda pom files reference the download repository with ID `camunda-nexus-release` (via `${nexus.release.repository.id}-release`). Without a matching server entry, Maven sends unauthenticated requests → 401.

2. The **"Run maven"** step (`mvn package`) does not set `NEXUS_USR` / `NEXUS_PSW` environment variables. Only the Publish steps set them. Since the settings.xml uses `${env.NEXUS_USR}` / `${env.NEXUS_PSW}`, credentials resolve to empty strings during the build phase.

See also: https://github.com/camunda/camunda/pull/46141 (confirms `camunda-nexus-release` as the standard server ID).

## Changes

### Bug fixes
- **`resources/settings.xml`**: Add `camunda-nexus-release` server entry with the same credential pattern as `camunda-nexus`
- **`action.yml`**: Set `NEXUS_USR` and `NEXUS_PSW` env vars on the "Run maven" step so credentials are available during dependency resolution

### Dependency updates
- `actions/upload-artifact` v4 → v7
- `EnricoMi/publish-unit-test-result-action` v2.3.0 → v2.23.0
- `Actions-R-Us/actions-tagger` latest → v2.0.3
- `actions/checkout` v4 → v6
- `actions/setup-python` v5 → v6

All version bumps are backward compatible (breaking changes are limited to Node.js 24 runtime, which GitHub-hosted runners already support).

related 
https://github.com/camunda/camunda/issues/41324